### PR TITLE
Enable print to terminal of url

### DIFF
--- a/ticktick/oauth2.py
+++ b/ticktick/oauth2.py
@@ -162,6 +162,7 @@ class OAuth2:
                  "provided in the url. Paste the url that you "
                  "were redirected to into the console")
         url = self._get_auth_url()
+        print(url)
         webbrowser.open(url)
 
     def _get_redirected_url(self):


### PR DESCRIPTION
For terminals like tmux there is no Webbrowser that can be called and instead of prompting the URL is not displayed. This print allows users to copy the URL and execute it manually