### PR TITLE
Update pytest to 7.4.3

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 httpx==0.21.1
-pytest==6.2.5
+pytest==7.4.3
 python-dotenv==0.19.2
 mkdocs-material==8.1.3
 mkdocstrings==0.16.2


### PR DESCRIPTION
Encountered an error with pytest which seems to be related to an import issue in the pytest_asyncio plugin. This plugin is trying to import Config from pytest, but it's failing. This could be due to a version compatibility issue between pytest and pytest_asyncio.

Updating pytest to its latest version has resolved the issue.