### PR TITLE
Fix login failing with 429 response

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@
 
 ## [Full Documentation](https://lazeroffmichael.github.io/ticktick-py/)
 
-## This fork aims to implement the habit, pomo, and focus feature. Feel free to contribute or contact me with any questions!
-
 ## Description
 `ticktick-py` is an unofficial API library for interacting with [TickTick.com](<https://www.ticktick.com/>). 
 It allows

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 ## [Full Documentation](https://lazeroffmichael.github.io/ticktick-py/)
 
+## This fork aims to implement the habit, pomo, and focus feature. Feel free to contribute or contact me with any questions!
+
 ## Description
 `ticktick-py` is an unofficial API library for interacting with [TickTick.com](<https://www.ticktick.com/>). 
 It allows

--- a/ticktick/api.py
+++ b/ticktick/api.py
@@ -17,8 +17,8 @@ class TickTickClient:
 
     INITIAL_BATCH_URL = BASE_URL + 'batch/check/0'
 
-    USER_AGENT = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:95.0) Gecko/20100101 Firefox/95.0"
-    X_DEVICE_ = '{"platform":"web","os":"OS X","device":"Firefox 95.0","name":"unofficial api!","version":4531,' \
+    USER_AGENT = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:123.0) Gecko/20100101 Firefox/123.0"
+    X_DEVICE_ = '{"platform":"web","os":"OS X","device":"Firefox 123.0","name":"unofficial api!","version":4531,' \
                 '"id":"6490' + secrets.token_hex(10) + '","channel":"website","campaign":"","websocket":""}'
 
     HEADERS = {'User-Agent': USER_AGENT,


### PR DESCRIPTION
The firefox version used in the request header seems to be too outdated as to not be accepted by the TickTick-API anymore. This increase to the newest firefox version fixes the login.
